### PR TITLE
7-add-check-for-stacked-label-to-prevent-merge

### DIFF
--- a/.github/workflows/check-stacked.yml
+++ b/.github/workflows/check-stacked.yml
@@ -1,0 +1,18 @@
+name: Check Stacked
+
+on:
+  pull_request:
+    types:
+      - opened
+      - labeled
+      - unlabeled
+
+jobs:
+  fail-if-stacked:
+    if: contains(github.event.pull_request.labels.*.name, 'stacked')
+    runs-on: ubuntu-latest
+    steps:
+      - name: Fail if PR is stacked on another branch.
+        run: |
+          echo "This PR is currently stacked."
+          exit 1


### PR DESCRIPTION
Added check stacked github action

The idea here is that stacked PRs can be labelled "stacked" and this
will prevent accidental merges when you have a number of PRs.