### PR TITLE
9 represent the electricity price with led strip

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 software/build
+software/managed_components
 software/sdkconfig
 software/sdkconfig.old
 .cache

--- a/software/dependencies.lock
+++ b/software/dependencies.lock
@@ -1,0 +1,15 @@
+dependencies:
+  idf:
+    component_hash: null
+    source:
+      type: idf
+    version: 5.2.1
+  zorxx/neopixel:
+    component_hash: 1de4d2cd727624743fddd9fbebe6389c594435900e677f8f33b1886d9a75f44d
+    source:
+      service_url: https://api.components.espressif.com/
+      type: service
+    version: 1.0.5
+manifest_hash: 1a6254455dbd7bda5a3dad997b066c74943f860ef586be7026b12c3377a9a086
+target: esp32
+version: 1.0.0

--- a/software/main/CMakeLists.txt
+++ b/software/main/CMakeLists.txt
@@ -1,4 +1,5 @@
 idf_component_register(SRCS "power-indicator.c"
                             "power.c"
                             "network.c"
+                            "indicator.c"
                     INCLUDE_DIRS ".")

--- a/software/main/Kconfig.projbuild
+++ b/software/main/Kconfig.projbuild
@@ -65,3 +65,23 @@ menu "WiFi Configuration"
     endchoice
 
 endmenu
+
+menu "Power Indicator"
+
+    orsource "$IDF_PATH/examples/common_components/env_caps/$IDF_TARGET/Kconfig.env_caps"
+
+    config POWER_INDICATOR_DATA_PIN
+        int "Data pin for ws2182b LEDs"
+        range ENV_GPIO_RANGE_MIN ENV_GPIO_OUT_RANGE_MAX
+        default 2
+        help
+            GPIO to use as a Data pin for ws2182b LED strip.
+
+    config POWER_INDICATOR_NUM_LED
+        int "Number of LEDs"
+        range 1 200
+        default 29
+        help
+            Number of ws2182b LEDs that are used as indicators.
+
+endmenu

--- a/software/main/idf_component.yml
+++ b/software/main/idf_component.yml
@@ -1,0 +1,17 @@
+## IDF Component Manager Manifest File
+dependencies:
+  zorxx/neopixel: "*"
+  ## Required IDF version
+  idf:
+    version: ">=5.1.0"
+  # # Put list of dependencies here
+  # # For components maintained by Espressif:
+  # component: "~1.0.0"
+  # # For 3rd party components:
+  # username/component: ">=1.0.0,<2.0.0"
+  # username2/component2:
+  #   version: "~1.0.0"
+  #   # For transient dependencies `public` flag can be set.
+  #   # `public` flag doesn't have an effect dependencies of the `main` component.
+  #   # All dependencies of `main` are public by default.
+  #   public: true

--- a/software/main/indicator.c
+++ b/software/main/indicator.c
@@ -4,7 +4,7 @@
 #include "neopixel.h"
 
 #define TAG "indicator"
-#define PIXEL_COUNT 29
+#define PIXEL_COUNT CONFIG_POWER_INDICATOR_NUM_LED
 
 struct indicator_handle
 {
@@ -30,12 +30,12 @@ bool indicator_init(gpio_num_t data_pin)
     return true;
 }
 
-bool indicator_set_colour(uint8_t red, uint8_t green, uint8_t blue)
+bool indicator_set_colour(struct indicator_colour colour)
 {
     for (int ii = 0; ii < PIXEL_COUNT; ii++)
     {
         indicator.pixels[ii].index = ii;
-        indicator.pixels[ii].rgb = NP_RGB(red, green, blue);
+        indicator.pixels[ii].rgb = NP_RGB(colour.red, colour.green, colour.blue);
     };
 
     return neopixel_SetPixel(indicator.neopixel, indicator.pixels, PIXEL_COUNT);

--- a/software/main/indicator.c
+++ b/software/main/indicator.c
@@ -1,0 +1,42 @@
+#include "indicator.h"
+#include "driver/gpio.h"
+#include "esp_log.h"
+#include "neopixel.h"
+
+#define TAG "indicator"
+#define PIXEL_COUNT 29
+
+struct indicator_handle
+{
+    tNeopixelContext *neopixel;
+    tNeopixel pixels[PIXEL_COUNT];
+} indicator;
+
+bool indicator_init(gpio_num_t data_pin)
+{
+    if (indicator.neopixel)
+    {
+        ESP_LOGW(TAG, "Indicator alreay intialised.");
+        return true;
+    }
+
+    indicator.neopixel = neopixel_Init(PIXEL_COUNT, data_pin);
+    if (!indicator.neopixel)
+    {
+        ESP_LOGE(TAG, "Failed to initialise indicator.");
+        return false;
+    }
+
+    return true;
+}
+
+bool indicator_set_colour(uint8_t red, uint8_t green, uint8_t blue)
+{
+    for (int ii = 0; ii < PIXEL_COUNT; ii++)
+    {
+        indicator.pixels[ii].index = ii;
+        indicator.pixels[ii].rgb = NP_RGB(red, green, blue);
+    };
+
+    return neopixel_SetPixel(indicator.neopixel, indicator.pixels, PIXEL_COUNT);
+}

--- a/software/main/indicator.h
+++ b/software/main/indicator.h
@@ -1,0 +1,8 @@
+#pragma once
+
+#include "driver/gpio.h"
+#include <stdint.h>
+
+bool indicator_init(gpio_num_t data_pin);
+
+bool indicator_set_colour(uint8_t red, uint8_t green, uint8_t blue);

--- a/software/main/indicator.h
+++ b/software/main/indicator.h
@@ -3,6 +3,28 @@
 #include "driver/gpio.h"
 #include <stdint.h>
 
+/** Structure for specifiying RGB colour. */
+struct indicator_colour
+{
+    uint8_t red;   /**< Red element */
+    uint8_t green; /**< Green element */
+    uint8_t blue;  /**< Blue element */
+};
+
+/**
+ * Initialise LED indicator module.
+ *
+ * @param data_pin GPIO pin to use as a data line for the WS2181b LEDs.
+ *
+ * @return @c true on success, else @c false.
+ */
 bool indicator_init(gpio_num_t data_pin);
 
-bool indicator_set_colour(uint8_t red, uint8_t green, uint8_t blue);
+/**
+ * Set the LED inidicator to the specified colour.
+ *
+ * @param colour Struct specifying the RGB values.
+ *
+ * @return @c true on is colour was successfully set, else @c false.
+ */
+bool indicator_set_colour(struct indicator_colour colour);

--- a/software/main/power-indicator.c
+++ b/software/main/power-indicator.c
@@ -5,6 +5,7 @@
 #include "freertos/task.h"
 #include "nvs_flash.h"
 
+#include "indicator.h"
 #include "network.h"
 #include "power.h"
 
@@ -21,6 +22,7 @@ static void main_task(void *arg)
     {
         price = power_get_price(handle);
         ESP_LOGI(TAG, "Price $%.2f\n", price);
+        (void)indicator_set_colour(0xff, 0x00, 0x00);
         vTaskDelay(pdMS_TO_TICKS(UPDATE_RATE_MS));
     }
 }
@@ -44,6 +46,12 @@ void app_main(void)
     if (!ok)
     {
         ESP_LOGE(TAG, "network initialisation failed.");
+    }
+
+    ok = indicator_init(GPIO_NUM_2);
+    if (!ok)
+    {
+        ESP_LOGE(TAG, "indicator initialisation failed.");
     }
 
     power = power_init(&power_config);

--- a/software/main/power-indicator.c
+++ b/software/main/power-indicator.c
@@ -13,16 +13,34 @@
 
 static const char *TAG = "power-indicator";
 
+/** Array of colours used to indicate power price. Indexed by enum power_price_descriptor. */
+struct indicator_colour power_colours[POWER_PRICE_NUM] = {
+    {0xFF, 0xFF, 0xFF}, {0x00, 0xFF, 0xFF}, {0x00, 0xFF, 0x00}, {0xFF, 0xA5, 0x00},
+    {0xFF, 0x8C, 0x00}, {0xFF, 0x00, 0x00}, {0x80, 0x00, 0x80},
+};
+
+/** Colour to use on an error condition. */
+struct indicator_colour error_colour = {};
+
 static void main_task(void *arg)
 {
     struct power_handle *handle = (struct power_handle *)arg;
 
-    float price;
+    enum power_price_descriptor price_descriptor;
     while (1)
     {
-        price = power_get_price(handle);
-        ESP_LOGI(TAG, "Price $%.2f\n", price);
-        (void)indicator_set_colour(0xff, 0x00, 0x00);
+        price_descriptor = power_get_price_descriptor(handle);
+        ESP_LOGI(TAG, "Price descriptor %d\n", price_descriptor);
+
+        if (price_descriptor < POWER_PRICE_NUM)
+        {
+            (void)indicator_set_colour(power_colours[price_descriptor]);
+        }
+        else
+        {
+            indicator_set_colour(error_colour);
+        }
+
         vTaskDelay(pdMS_TO_TICKS(UPDATE_RATE_MS));
     }
 }
@@ -48,7 +66,7 @@ void app_main(void)
         ESP_LOGE(TAG, "network initialisation failed.");
     }
 
-    ok = indicator_init(GPIO_NUM_2);
+    ok = indicator_init(CONFIG_POWER_INDICATOR_DATA_PIN);
     if (!ok)
     {
         ESP_LOGE(TAG, "indicator initialisation failed.");

--- a/software/main/power.c
+++ b/software/main/power.c
@@ -18,3 +18,8 @@ double power_get_price(struct power_handle *handle)
 
     return 0.0;
 }
+
+enum power_price_descriptor power_get_price_descriptor(struct power_handle *handle)
+{
+    return POWER_PRICE_NEUTRAL;
+}

--- a/software/main/power.h
+++ b/software/main/power.h
@@ -13,6 +13,18 @@ struct power_config
     uint8_t reserved;
 };
 
+enum power_price_descriptor
+{
+    POWER_PRICE_NEGATIVE,
+    POWER_PRICE_EXTREME_LOW,
+    POWER_PRICE_VERY_LOW,
+    POWER_PRICE_LOW,
+    POWER_PRICE_NEUTRAL,
+    POWER_PRICE_HIGH,
+    POWER_PRICE_SPIKE,
+    POWER_PRICE_NUM,
+};
+
 /**
  * Function to initialise the power handle.
  *
@@ -33,3 +45,5 @@ struct power_handle *power_init(struct power_config *config);
  * @return Current electricity price in dollars on success, @c DBL_MAX on error.
  */
 double power_get_price(struct power_handle *handle);
+
+enum power_price_descriptor power_get_price_descriptor(struct power_handle *handle);


### PR DESCRIPTION
Updated indicator module and added power price descriptor function

* Added a neopixel component from esp registry. Abstracted this behind
  indicator module api.
* Allow specifying the data pin and number of LEDs using Kconfig variables
* Added power_get_price_descriptor() and accompanying enum. This is
  because the Amber (power company) bases its colours/price indicators
  in relation to DMO (Default Market Offering). As they don't appear to
  provide DMO in their API it seems easier to base it on the price
  descriptor field that they do provide.
* Added logic to display different colours based on the returned price
  descriptor.