### PR TITLE
14 add GitHub action to build esp idf target

### DIFF
--- a/.github/workflows/build-check.yml
+++ b/.github/workflows/build-check.yml
@@ -1,5 +1,5 @@
 name: Build Check
-on: [push, pull_request]
+on: [pull_request]
 
 jobs:
   build:

--- a/.github/workflows/build-check.yml
+++ b/.github/workflows/build-check.yml
@@ -1,0 +1,18 @@
+name: Build Check
+on: [push, pull_request]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout repo
+      uses: actions/checkout@v4
+      with:
+        submodules: 'recursive'
+    - name: esp-idf build
+      uses: espressif/esp-idf-ci-action@v1
+      with:
+        esp_idf_version: v5.1.1
+        target: esp32s3
+        path: 'software'

--- a/.github/workflows/clang-format-check.yml
+++ b/.github/workflows/clang-format-check.yml
@@ -1,5 +1,5 @@
 name: clang-format Check
-on: [push, pull_request]
+on: [pull_request]
 jobs:
   formatting-check:
     name: Formatting Check


### PR DESCRIPTION
Adds github action to build the code. This is to catch any accidental breaking changes before they are merged. Uses the `esp-idf-ci-action` provided by Espressif.
Additionally, updated the actions to only run on 'pull requests'. Main reason is to conserve minutes.