### PR TITLE
Updated indicator to use an LED matrix instead of LED strip

### DIFF
--- a/software/main/Kconfig.projbuild
+++ b/software/main/Kconfig.projbuild
@@ -83,11 +83,29 @@ menu "Power Indicator"
         help
             GPIO to use as a Data pin for ws2182b LED strip.
 
-    config POWER_INDICATOR_NUM_LED
-        int "Number of LEDs"
-        range 1 200
-        default 29
+    menu "LED Matrix Module Configuration"
+
+    config LED_MATRIX_WIDTH
+        int "Matrix Width"
+        range 1 32
+        default 8
         help
-            Number of ws2182b LEDs that are used as indicators.
+            Specify the width of the LED matrix in pixels. The valid range is 1 to 32.
+
+    config LED_MATRIX_HEIGHT
+        int "Matrix Height"
+        range 1 32
+        default 8
+        help
+            Specify the height of the LED matrix in pixels. The valid range is 1 to 32.
+
+    config LED_MATRIX_STATUS_SEGMENTS
+        int "Status Segments"
+        range 1 LED_MATRIX_WIDTH
+        default 4
+        help
+            Specify the number of status segments. This value cannot exceed the matrix width.
+
+    endmenu
 
 endmenu

--- a/software/main/indicator.c
+++ b/software/main/indicator.c
@@ -4,13 +4,45 @@
 #include "neopixel.h"
 
 #define TAG "indicator"
-#define PIXEL_COUNT CONFIG_POWER_INDICATOR_NUM_LED
+#define BRIGHTNESS_DENOMINATOR 60
+
+#define MATRIX_WIDTH CONFIG_LED_MATRIX_WIDTH
+#define MATRIX_HEIGHT CONFIG_LED_MATRIX_HEIGHT
+#define PIXEL_COUNT (MATRIX_WIDTH * MATRIX_HEIGHT)
+
+#define STATUS_SEGMENTS CONFIG_LED_MATRIX_STATUS_SEGMENTS
+
+/** Structure for specifiying RGB colour. */
+struct indicator_colour
+{
+    uint8_t red;   /**< Red element */
+    uint8_t green; /**< Green element */
+    uint8_t blue;  /**< Blue element */
+};
+
+/** Array of colours corresponding to the @c indicator_colour_specifier values. */
+static struct indicator_colour colours[] = {
+    [RED] = {255, 0, 0},       [GREEN] = {0, 255, 0},    [BLUE] = {0, 0, 255},
+    [YELLOW] = {255, 255, 0},  [CYAN] = {0, 255, 255},   [PURPLE] = {255, 0, 255},
+    [WHITE] = {255, 255, 255}, [ORANGE] = {255, 165, 0}, [BLACK] = {0, 0, 0}};
 
 struct indicator_handle
 {
     tNeopixelContext *neopixel;
     tNeopixel pixels[PIXEL_COUNT];
 } indicator;
+
+/**
+ * Helper function to set the colour of a given neopixel. Main reason is to allow for configuration
+ * of a global brightness setting.
+ */
+static void set_colour(tNeopixel *pixel, enum indicator_colour_specifier colour)
+{
+    uint8_t brightness_denominator = BRIGHTNESS_DENOMINATOR;
+    pixel->rgb = NP_RGB(colours[colour].red / brightness_denominator,
+                        colours[colour].green / brightness_denominator,
+                        colours[colour].blue / brightness_denominator);
+}
 
 bool indicator_init(gpio_num_t data_pin)
 {
@@ -27,16 +59,79 @@ bool indicator_init(gpio_num_t data_pin)
         return false;
     }
 
-    return true;
-}
-
-bool indicator_set_colour(struct indicator_colour colour)
-{
     for (int ii = 0; ii < PIXEL_COUNT; ii++)
     {
         indicator.pixels[ii].index = ii;
-        indicator.pixels[ii].rgb = NP_RGB(colour.red, colour.green, colour.blue);
     };
+
+    return neopixel_SetPixel(indicator.neopixel, indicator.pixels, PIXEL_COUNT);
+}
+
+static void update_row(uint8_t row_idx, enum indicator_colour_specifier colour, uint8_t percent)
+{
+    uint32_t pos_offset = row_idx * MATRIX_WIDTH;
+    uint32_t num_lit_positions = (percent * MATRIX_WIDTH) / 100;
+
+    // Determine the direction of iteration
+    int start =
+        (row_idx % 2 == 0) ? (MATRIX_WIDTH - 1) : 0;  // Even rows: reverse, Odd rows: forward
+    int end = (row_idx % 2 == 0) ? -1 : MATRIX_WIDTH; // Reverse uses -1 as the end condition
+    int step = (row_idx % 2 == 0) ? -1 : 1;           // Step: -1 for reverse, 1 for forward
+
+    for (int ii = start; ii != end; ii += step)
+    {
+        if (num_lit_positions > 0)
+        {
+            num_lit_positions--;
+            set_colour(&indicator.pixels[ii + pos_offset], colour);
+        }
+        else
+        {
+            set_colour(&indicator.pixels[ii + pos_offset], BLACK);
+        }
+    }
+}
+
+bool indicator_set_row(uint8_t row_idx, enum indicator_colour_specifier colour, uint8_t percent)
+{
+    if (!row_idx)
+    {
+        ESP_LOGE(TAG, "Index 0 is reserved for the status row.\n");
+        return false;
+    }
+
+    if (row_idx >= MATRIX_HEIGHT)
+    {
+        ESP_LOGE(TAG, "Row index (%u) exceeds maxium allowed value (%u)\n", row_idx,
+                 MATRIX_HEIGHT - 1);
+        return false;
+    }
+
+    update_row(row_idx, colour, percent);
+
+    return neopixel_SetPixel(indicator.neopixel, indicator.pixels, PIXEL_COUNT);
+}
+
+bool indicator_set_status(uint8_t status_idx, enum indicator_colour_specifier colour)
+{
+    if (status_idx >= STATUS_SEGMENTS)
+    {
+        ESP_LOGE(TAG, "Status index (%u) exceeds maxium allow value (%u)\n", status_idx,
+                 STATUS_SEGMENTS);
+        return false;
+    }
+
+    uint32_t num_pixels = (MATRIX_WIDTH / STATUS_SEGMENTS);
+    if (status_idx == STATUS_SEGMENTS - 1)
+    {
+        num_pixels += (MATRIX_WIDTH % STATUS_SEGMENTS);
+    }
+    uint32_t pos_offset = (MATRIX_WIDTH / STATUS_SEGMENTS) * status_idx;
+
+    for (int ii = MATRIX_WIDTH - 1; num_pixels; ii--, num_pixels--)
+    {
+        set_colour(&indicator.pixels[ii - pos_offset], colour);
+    }
 
     return neopixel_SetPixel(indicator.neopixel, indicator.pixels, PIXEL_COUNT);
 }

--- a/software/main/indicator.h
+++ b/software/main/indicator.h
@@ -4,7 +4,8 @@
 #include <stdint.h>
 
 /** Enum for colour specifiers. */
-enum indicator_colour_specifier {
+enum indicator_colour_specifier
+{
     RED,
     GREEN,
     BLUE,

--- a/software/main/indicator.h
+++ b/software/main/indicator.h
@@ -3,12 +3,18 @@
 #include "driver/gpio.h"
 #include <stdint.h>
 
-/** Structure for specifiying RGB colour. */
-struct indicator_colour
-{
-    uint8_t red;   /**< Red element */
-    uint8_t green; /**< Green element */
-    uint8_t blue;  /**< Blue element */
+/** Enum for colour specifiers. */
+enum indicator_colour_specifier {
+    RED,
+    GREEN,
+    BLUE,
+    YELLOW,
+    CYAN,
+    MAGENTA,
+    WHITE,
+    ORANGE,
+    PURPLE,
+    BLACK,
 };
 
 /**
@@ -27,4 +33,6 @@ bool indicator_init(gpio_num_t data_pin);
  *
  * @return @c true on is colour was successfully set, else @c false.
  */
-bool indicator_set_colour(struct indicator_colour colour);
+bool indicator_set_row(uint8_t row_idx, enum indicator_colour_specifier colour, uint8_t percent);
+
+bool indicator_set_status(uint8_t status_idx, enum indicator_colour_specifier colour);

--- a/software/main/network.c
+++ b/software/main/network.c
@@ -93,7 +93,7 @@ static void event_handler(void *arg, esp_event_base_t event_base, int32_t event_
     }
 }
 
-void wifi_init_sta(void)
+static bool wifi_init_sta(void)
 {
     s_wifi_event_group = xEventGroupCreate();
 
@@ -146,6 +146,7 @@ void wifi_init_sta(void)
     {
         ESP_LOGI(TAG, "connected to ap SSID:%s password:%s", EXAMPLE_ESP_WIFI_SSID,
                  EXAMPLE_ESP_WIFI_PASS);
+        return true;
     }
     else if (bits & WIFI_FAIL_BIT)
     {
@@ -156,11 +157,12 @@ void wifi_init_sta(void)
     {
         ESP_LOGE(TAG, "UNEXPECTED EVENT");
     }
+
+    return false;
 }
 
 bool network_init(void)
 {
     ESP_LOGI(TAG, "ESP_WIFI_MODE_STA");
-    wifi_init_sta();
-    return true;
+    return wifi_init_sta();
 }


### PR DESCRIPTION
In order to display more information in an easy to understand way we are switching to a matrix LED array. This will allow us to have multiple rows which we can use to communicate different information more clearly. Additionally the first row is reserved as a status bar which can be broken up into different segments to display things like Wi-Fi connection status.

Additionally, the network module was updated to return false if the connection failed.